### PR TITLE
Unit tests handle local daylight time

### DIFF
--- a/test/test_udatetime.py
+++ b/test/test_udatetime.py
@@ -53,10 +53,16 @@ class Test(unittest.TestCase):
         DAY = 86400
         HOUR = 3600
         TZ_CEST = udatetime.TZFixedOffset(60 * 2)
+        UTC = udatetime.TZFixedOffset(0)
+
+        # NB: datetime.fromtimestamp() and udatetime.fromtimestamp() handle the
+        # implicit local timezone differently, so when used without an explicit
+        # timestamp they will not always agree
+        # see: 
 
         for t in range(0, DAY - (2 * HOUR), HOUR):
-            dt = datetime.fromtimestamp(t)
-            udt = udatetime.fromtimestamp(t)
+            dt = datetime.fromtimestamp(t, UTC)
+            udt = udatetime.fromtimestamp(t, UTC)
 
             self.assertIsInstance(udt, datetime)
             self.assertEqual(udt.year, dt.year)

--- a/test/test_udatetime.py
+++ b/test/test_udatetime.py
@@ -58,7 +58,7 @@ class Test(unittest.TestCase):
         # NB: datetime.fromtimestamp() and udatetime.fromtimestamp() handle the
         # implicit local timezone differently, so when used without an explicit
         # timestamp they will not always agree
-        # see: 
+        # see: https://github.com/freach/udatetime/issues/10
 
         for t in range(0, DAY - (2 * HOUR), HOUR):
             dt = datetime.fromtimestamp(t, UTC)


### PR DESCRIPTION
Fixes #10 

Modify the unit tests to avoid the problem that udatetime and datetime handle utc offset from implicit local timezone differently.
