### PR TITLE
Fix out-of-bounds read

### DIFF
--- a/src/rfc3339.c
+++ b/src/rfc3339.c
@@ -256,7 +256,7 @@ static void _parse_time(char *time_string, time_struct *t) {
     // check for fractions
     if (*tokens == '.') {
         tokens++;
-        char fractions[6] = {0};
+        char fractions[7] = {0};
 
         // Substring fractions, max 6 digits for usec
         for (unsigned int i = 0; i < 6; i++) {


### PR DESCRIPTION
Increase the size of the fractions buffer to 7, to include the
terminating null byte ('\0'). Otherwise sscanf() will read past the
buffer area with unpredictable results.