### PR TITLE
Fix a DST-related issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,10 @@ date-time format.
 serialization and deserialization of RFC3339 date-time strings. `udatetime` is
 using Python's [datetime class](https://docs.python.org/2/library/datetime.html)
 under the hood and code already using `datetime` should be able to easily
-switch to `udatetime`. All `datetime` objects created by `udatetime` are timezone
-aware.
+switch to `udatetime`. All `datetime` objects created by `udatetime` are
+timezone-aware. The timezones that `udatetime` uses are fixed-offset timezones,
+meaning that they don't observe daylight savings time (DST), and thus return a
+fixed offset from UTC all year round.
 
 |          | Support            | Performance optimized | Implementation |
 | -------- |:------------------:|:---------------------:| -------------- |

--- a/src/rfc3339.c
+++ b/src/rfc3339.c
@@ -548,10 +548,10 @@ static PyObject *FixedOffset_utcoffset(FixedOffset *self, PyObject *args) {
 
 /*
  * def dst(self, dt):
- *     return timedelta(seconds=self.offset * 60)
+ *     return timedelta(0)
  */
 static PyObject *FixedOffset_dst(FixedOffset *self, PyObject *args) {
-    return PyDelta_FromDSU(0, self->offset * 60, 0);
+    return PyDelta_FromDSU(0, 0, 0);
 }
 
 /*

--- a/test/test_udatetime.py
+++ b/test/test_udatetime.py
@@ -2,6 +2,8 @@ import unittest
 from datetime import datetime, timedelta, tzinfo
 import udatetime
 
+NO_DST = timedelta(0)
+
 
 class Test(unittest.TestCase):
 
@@ -17,6 +19,9 @@ class Test(unittest.TestCase):
         self.assertEqual(now.minute, dt_now.minute)
         self.assertEqual(now.second, dt_now.second)
         # self.assertEqual(now.microsecond, dt_now.microsecond)
+
+        self.assertEqual(now.utcoffset(), timedelta(0))
+        self.assertEqual(now.dst(), NO_DST)
 
     def test_now(self):
         dt_now = datetime.now()
@@ -43,6 +48,8 @@ class Test(unittest.TestCase):
         self.assertEqual(dt.minute, 33)
         self.assertEqual(dt.second, 20)
         self.assertEqual(dt.microsecond, 123000)
+        self.assertEqual(dt.utcoffset(), timedelta(hours=1, minutes=30))
+        self.assertEqual(dt.dst(), NO_DST)
         self.assertEqual(udatetime.to_string(dt), rfc3339)
 
         rfc3339 = '2016-07-18T12:58:26.485897-02:00'
@@ -68,6 +75,9 @@ class Test(unittest.TestCase):
             self.assertEqual(udt.second, dt.second)
             self.assertEqual(udt.microsecond, dt.microsecond)
 
+            self.assertEqual(udt.utcoffset(), timedelta(0))
+            self.assertEqual(udt.dst(), NO_DST)
+
         for t in range(0, DAY, HOUR):
             dt = datetime.fromtimestamp(t, TZ_CEST)
             udt = udatetime.fromtimestamp(t, TZ_CEST)
@@ -82,6 +92,9 @@ class Test(unittest.TestCase):
             self.assertEqual(udt.second, dt.second)
             self.assertEqual(udt.microsecond, dt.microsecond)
 
+            self.assertEqual(udt.utcoffset(), timedelta(hours=2))
+            self.assertEqual(udt.dst(), NO_DST)
+
         for t in range(0, DAY * -1, HOUR * -1):
             dt = datetime.fromtimestamp(t, TZ_CEST)
             udt = udatetime.fromtimestamp(t, TZ_CEST)
@@ -95,6 +108,9 @@ class Test(unittest.TestCase):
             self.assertEqual(udt.minute, dt.minute)
             self.assertEqual(udt.second, dt.second)
             self.assertEqual(udt.microsecond, dt.microsecond)
+
+            self.assertEqual(udt.utcoffset(), timedelta(hours=2))
+            self.assertEqual(udt.dst(), NO_DST)
 
     def test_utcfromtimestamp(self):
         DAY = 86400
@@ -113,6 +129,9 @@ class Test(unittest.TestCase):
             self.assertEqual(udt.second, dt.second)
             self.assertEqual(udt.microsecond, dt.microsecond)
 
+            self.assertEqual(udt.utcoffset(), timedelta(0))
+            self.assertEqual(udt.dst(), NO_DST)
+
         for t in range(0, DAY * -1, HOUR * -1):
             dt = datetime.utcfromtimestamp(t)
             udt = udatetime.utcfromtimestamp(t)
@@ -125,6 +144,9 @@ class Test(unittest.TestCase):
             self.assertEqual(udt.minute, dt.minute)
             self.assertEqual(udt.second, dt.second)
             self.assertEqual(udt.microsecond, dt.microsecond)
+
+            self.assertEqual(udt.utcoffset(), timedelta(0))
+            self.assertEqual(udt.dst(), NO_DST)
 
     def test_broken_from_string(self):
         invalid = [
@@ -161,23 +183,29 @@ class Test(unittest.TestCase):
         rfc3339 = '2016-07-15T12:33:20.123000+01:30'
         dt = udatetime.from_string(rfc3339)
         offset = dt.tzinfo.utcoffset()
+        dst = dt.tzinfo.dst()
 
         self.assertIsInstance(offset, timedelta)
         self.assertEqual(offset.total_seconds() / 60, 90)
+        self.assertEqual(dst, NO_DST)
 
         rfc3339 = '2016-07-15T12:33:20.123000Z'
         dt = udatetime.from_string(rfc3339)
         offset = dt.tzinfo.utcoffset()
+        dst = dt.tzinfo.dst()
 
         self.assertIsInstance(offset, timedelta)
         self.assertEqual(offset.total_seconds(), 0)
+        self.assertEqual(dst, NO_DST)
 
         rfc3339 = '2016-07-15T12:33:20.123000-02:00'
         dt = udatetime.from_string(rfc3339)
         offset = dt.tzinfo.utcoffset()
+        dst = dt.tzinfo.dst()
 
         self.assertIsInstance(offset, timedelta)
         self.assertEqual(offset.total_seconds() / 60, -120)
+        self.assertEqual(dst, NO_DST)
 
     def test_precision(self):
         t = 1469897308.549871

--- a/udatetime/_pure.py
+++ b/udatetime/_pure.py
@@ -14,7 +14,7 @@ class TZFixedOffset(tzinfo):
         return timedelta(seconds=self.offset * 60)
 
     def dst(self, dt=None):
-        return timedelta(seconds=self.offset * 60)
+        return timedelta(0)
 
     def tzname(self, dt=None):
         sign = '+'


### PR DESCRIPTION
This PR fixes an issue that has to do with the DST information that is
returned by the `FixedOffset` class. It also updates the tests and
provides some extra information in the `README` about the timezone
classes of `udatetime`.   