### PR TITLE
Explicitly include <sys/timeb.h> for ftime() and struct timeb

### DIFF
--- a/src/rfc3339.c
+++ b/src/rfc3339.c
@@ -10,6 +10,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/timeb.h>
 #include <time.h>
 
 

--- a/src/rfc3339.c
+++ b/src/rfc3339.c
@@ -10,9 +10,11 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/timeb.h>
 #include <time.h>
 
+#ifdef HAVE_FTIME
+#include <sys/timeb.h>
+#endif
 
 #define RFC3339_VERSION "0.0.16"
 #define DAY_IN_SECS 86400


### PR DESCRIPTION
Needed to build on Python 3.9.

Fixes: #32

Can't see what changed in the Python 3.9 headers, where this used to be transitively included and isn't any more.

Note, `ftime()` is deprecated, and should be replaced with `gettimeofday()`. This PR *does not* do that.