### PR TITLE
add optional faster and more granular clock for getting current time

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,9 @@ elif sys.version_info.major == 2:
 elif sys.version_info.major == 3:
     macros.append(('_PYTHON3', '1'))
 
+if os.environ.get('USE_CLOCKGETTIME', '1') == '1':
+    macros.append(('HAVE_CLOCKGETTIME', '1'))
+
 ext_modules = []
 
 if __pypy__ is None:

--- a/src/rfc3339.c
+++ b/src/rfc3339.c
@@ -83,11 +83,19 @@ static int _get_local_utc_offset(void) {
     return local_utc_offset;
 }
 
+#if defined(__MACH__)
+#define CLOCK_REALTIME_COARSE CLOCK_REALTIME
+#endif
+
 /* Get current time using gettimeofday(), ftime() or time() depending on
  * support.
  */
 static double _gettime(void) {
-#if defined(HAVE_GETTIMEOFDAY)
+#if defined(HAVE_CLOCKGETTIME)
+    struct timespec ts;
+    clock_gettime(CLOCK_REALTIME_COARSE, &ts);
+    return ((double)ts.tv_sec) + ((double)ts.tv_nsec * 0.000000001);
+#elif defined(HAVE_GETTIMEOFDAY)
     // => Use gettimeofday() in usec
     struct timeval t;
 #if defined(GETTIMEOFDAY_NO_TZ)


### PR DESCRIPTION
`udatetime.utcnow()` behavior:

## Linux

**new**:
- 113 ns ± 5.09 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)
- includes useconds

**old**:
- 148 ns ± 2.22 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)
- rounded to millis


## Mac
**new**:
- 93.2 ns ± 0.312 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)
- includes useconds

**old**:
- 96.7 ns ± 0.718 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)
- rounded to millis
